### PR TITLE
MM5-4557 Added missing item security for the `MediaManager Favourites…

### DIFF
--- a/DC/5.6.0/Metadata/Asset/Shared/Asset info/media manager favourites slave.dcl
+++ b/DC/5.6.0/Metadata/Asset/Shared/Asset info/media manager favourites slave.dcl
@@ -17,3 +17,17 @@ resource metafield_label mediamanager_favourites_slave {
     label = resource.slave_metafield.mediamanager_favourites_slave.name
     language_id = resource.language.english.id
 }
+
+resource item_security mediamanager_favourites_slave__anonymous {
+    accessor_item_id = resource.member_group.anonymous.item_id
+    item_id = resource.slave_metafield.mediamanager_favourites_slave.item_id
+    read = true
+    write = false
+}
+
+resource item_security mediamanager_favourites_slave__trusted {
+    accessor_item_id = resource.member_group.trusted.item_id
+    item_id = resource.slave_metafield.mediamanager_favourites_slave.item_id
+    read = true
+    write = true
+}


### PR DESCRIPTION
… Slave` metafield, causing favorites to not work.