### PR TITLE
DAM-5938 dcl section for .plt --> format 3 was missing

### DIFF
--- a/DC/5.6.0/Transcodes/standard/cad.dcl
+++ b/DC/5.6.0/Transcodes/standard/cad.dcl
@@ -418,6 +418,26 @@ resource media_transcode hpgl_plot_plt__preview_large_50200 {
     }
 }
 
+resource media_transcode hpgl_plot_plt__preview_thumb_50201 {
+    name = 'HPGL Plot (.plt) - Preview Thumb'
+    description = ''
+    is_public = true
+    settings = ''
+    encoder_profile_name = ''
+    prefix = ''
+    copy_target_icc_profile = false
+    only_explicit_use = false
+    prog_id = 'DigiAsposeJobs.JobCadPreview'
+    folder_id = resource.transcode_folder.standard_10001.id
+    embed_metadefinition = ''
+    source_media_format_id = resource.media_format.hpgl_plot_plt_50072.media_format_id
+    target_media_format_id = resource.media_format.thumb_200x120_3.media_format_id
+    prevref = 0
+    autolink = {
+        item_guid = '9201c41d-11bb-4127-9dcb-752a480710fd'
+    }
+}
+
 resource media_transcode hpgl_plot_plt__preview_pdf_50202 {
     name = 'HPGL Plot (.plt) - Preview Pdf'
     description = ''


### PR DESCRIPTION
Jira Ticket: https://digizuite.atlassian.net/browse/DAM-5938

a media_transcode dcl section for plt was missing / deleted

(50072 --> 3)