### PR TITLE
Changes role name to be correct and added can_publish to system user

### DIFF
--- a/DC/5.7.0/Groups/User type/groups.dcl
+++ b/DC/5.7.0/Groups/User type/groups.dcl
@@ -282,7 +282,7 @@ resource member_group super_administrator {
         }, {
             constant = 'Collection_can_share_link'
         }, {
-            constant = 'Can_Email_Crop'
+            constant = 'Can_crop_email'
         }, {
             constant = 'Can_publish'
         }]

--- a/DC/5.7.0/Users/System users/members.dcl
+++ b/DC/5.7.0/Users/System users/members.dcl
@@ -38,6 +38,8 @@ resource member system {
             constant = 'Uploader_ShowFolderSelector'
         }, {
             constant = 'Editor_SystemTools_PlayerTemplate'
+        }, {
+            constant = 'Can_publish'
         }]
     autolink = {
         item_guid = 'a04cad8f-ea2f-438d-8003-ce4e54d25985'

--- a/DC/5.8.0/Groups/User type/groups.dcl
+++ b/DC/5.8.0/Groups/User type/groups.dcl
@@ -282,7 +282,7 @@ resource member_group super_administrator {
         }, {
             constant = 'Collection_can_share_link'
         }, {
-            constant = 'Can_Email_Crop'
+            constant = 'Can_crop_email'
         }, {
             constant = 'Can_publish'
         }]

--- a/DC/5.8.0/Users/System users/members.dcl
+++ b/DC/5.8.0/Users/System users/members.dcl
@@ -38,6 +38,8 @@ resource member system {
             constant = 'Uploader_ShowFolderSelector'
         }, {
             constant = 'Editor_SystemTools_PlayerTemplate'
+        }, {
+            constant = 'Can_publish'
         }]
     autolink = {
         item_guid = 'a04cad8f-ea2f-438d-8003-ce4e54d25985'


### PR DESCRIPTION
The explanation of the can_crop_email rename is that it was named differently in the role enum in DC and in the database table.

From 5.7.0 this naming has been corrected and hence we need to do the same for configuration management.

This changes is not part of 5.6.0 and therefore should not be changed in 5.6.0.

The can_publish role is just needed on the system user