### PR TITLE
DAM-6556 Rename role Can_Configure_External_Sharing to Can_configure_metadata_sharing

### DIFF
--- a/DC/5.7.0/Groups/User type/groups.dcl
+++ b/DC/5.7.0/Groups/User type/groups.dcl
@@ -260,7 +260,7 @@ resource member_group super_administrator {
         }, {
             constant = 'Can_manage_filters_and_fields'
         }, {
-            constant = 'Can_configure_external_sharing'
+            constant = 'Can_configure_metadata_sharing'
         }, {
             constant = 'Can_view_service_health'
         }, {
@@ -417,7 +417,7 @@ resource member_group administrator_22 {
         }, {
             constant = 'Can_manage_filters_and_fields'
         }, {
-            constant = 'Can_configure_external_sharing'
+            constant = 'Can_configure_metadata_sharing'
         }, {
             constant = 'Can_view_service_health'
         }, {

--- a/DC/5.7.0/Users/User profiles/member.dcl
+++ b/DC/5.7.0/Users/User profiles/member.dcl
@@ -248,7 +248,7 @@ resource member superadministrator {
           }, {
               constant = 'Can_manage_filters_and_fields'
           }, {
-              constant = 'Can_configure_external_sharing'
+              constant = 'Can_configure_metadata_sharing'
           }, {
               constant = 'Can_view_service_health'
           }, {

--- a/DC/5.8.0/Groups/User type/groups.dcl
+++ b/DC/5.8.0/Groups/User type/groups.dcl
@@ -260,7 +260,7 @@ resource member_group super_administrator {
         }, {
             constant = 'Can_manage_filters_and_fields'
         }, {
-            constant = 'Can_configure_external_sharing'
+            constant = 'Can_configure_metadata_sharing'
         }, {
             constant = 'Can_view_service_health'
         }, {
@@ -417,7 +417,7 @@ resource member_group administrator_22 {
         }, {
             constant = 'Can_manage_filters_and_fields'
         }, {
-            constant = 'Can_configure_external_sharing'
+            constant = 'Can_configure_metadata_sharing'
         }, {
             constant = 'Can_view_service_health'
         }, {

--- a/DC/5.8.0/Users/User profiles/member.dcl
+++ b/DC/5.8.0/Users/User profiles/member.dcl
@@ -248,7 +248,7 @@ resource member superadministrator {
           }, {
               constant = 'Can_manage_filters_and_fields'
           }, {
-              constant = 'Can_configure_external_sharing'
+              constant = 'Can_configure_metadata_sharing'
           }, {
               constant = 'Can_view_service_health'
           }, {


### PR DESCRIPTION
Rename role Can_Configure_External_Sharing to Can_configure_metadata_sharing

## Links

JIRA ticket: https://digizuite.atlassian.net/browse/DAM-6556

See also Pull Request: 
https://github.com/Digizuite/damcenter/pull/992