### PR TITLE
DAM-6723 Renamed Grayscale to Gray and added LinearGray

### DIFF
--- a/MM/5.8.0/config/media_manager_5/fields/custom_quality_color_spaces.dcl
+++ b/MM/5.8.0/config/media_manager_5/fields/custom_quality_color_spaces.dcl
@@ -5,10 +5,17 @@ resource configservice_combo_config_field_option custom_quality_color_spaces__cm
     is_default_selected = true
 }
 
-resource configservice_combo_config_field_option custom_quality_color_spaces__grayscale {
+resource configservice_combo_config_field_option custom_quality_color_spaces__gray {
     configservice_field_id = resource.configservice_multi_combo_config_field.custom_quality_color_spaces.id
-    value = 'Grayscale'
-    title = 'Grayscale'
+    value = 'gray'
+    title = 'Gray'
+    is_default_selected = true
+}
+
+resource configservice_combo_config_field_option custom_quality_color_spaces__lineargray {
+    configservice_field_id = resource.configservice_multi_combo_config_field.custom_quality_color_spaces.id
+    value = 'LinearGray'
+    title = 'Linear Gray'
     is_default_selected = true
 }
 


### PR DESCRIPTION
grayscale is no longer supported as a colorspace by imagemagick

new values:
gray - matches old grayscale
lineargray - linear grayscale