### PR TITLE
Fixed missing audio transcode for asset type audio

### DIFF
--- a/DC/5.8.0/transcodes/import_10000/audio_preview_10043.dcl
+++ b/DC/5.8.0/transcodes/import_10000/audio_preview_10043.dcl
@@ -1,0 +1,19 @@
+resource media_transcode audio_preview_10043 {
+    name = 'AUDIO_preview'
+    description = ''
+    is_public = true
+    settings = ''
+    encoder_profile_name = ''
+    prefix = ''
+    copy_target_icc_profile = false
+    only_explicit_use = false
+    prog_id = 'DigiFFMpegJobs.JobFFMpegProfile'
+    folder_id = resource.transcode_folder.import_10000.id
+    embed_metadefinition = ''
+    source_media_format_id = resource.media_format.audio_50029.media_format_id
+    target_media_format_id = resource.media_format.audio_preview_10045.media_format_id
+    prevref = 0
+    autolink = {
+        item_guid = '31348a47-7ed3-4298-981d-8b8c359bd1e9'
+    }
+}


### PR DESCRIPTION
Fixed missing audio transcode for audio files otherwise import fails (default perview for asset_type_configuration)

issue seen on Erhvervshus fyn