### PR TITLE
DAM-7831 Get rid of the 'Digizuite' prefix in the 'Published to' tree…

### DIFF
--- a/OOBE/6.0.1/metadata/asset/shared/options_50028/published_to.dcl
+++ b/OOBE/6.0.1/metadata/asset/shared/options_50028/published_to.dcl
@@ -107,7 +107,7 @@ resource tree_metafield published_to {
 resource tree_node_label digizuite_media_manager {
     tree_node_id = resource.tree_node.published_to__digizuite_media_manager.tree_node_id
     language_id = data.language.english.id
-    label = 'Digizuite™ Media Manager'
+    label = 'Media Manager'
 }
 
 resource tree_node_label internal_access {

--- a/OOBE/6.1.0/metafield_group/published_to.dcl
+++ b/OOBE/6.1.0/metafield_group/published_to.dcl
@@ -110,7 +110,7 @@ resource tree_metafield published_to {
 resource tree_node_label digizuite_media_manager {
     tree_node_id = resource.tree_node.published_to__digizuite_media_manager.tree_node_id
     language_id = data.language.english.id
-    label = 'Digizuite™ Media Manager'
+    label = 'Media Manager'
 }
 
 resource tree_node_label internal_access {


### PR DESCRIPTION
… node.

We might have to change this again, but this will suffice for now...

https://digizuite.atlassian.net/browse/DAM-7831

Requires https://github.com/Digizuite/digizuite.core/pull/2854 to avoid breaking existing custom layers.