### PR TITLE
bug/MM5-5155: Portal Config Settings :: Mail templates :: Error Message Missing for Empty Body in Mail Template Creation

### DIFF
--- a/MM/6.1.0/config/media_manager_5/labels/Config Manager.dcl
+++ b/MM/6.1.0/config/media_manager_5/labels/Config Manager.dcl
@@ -1739,11 +1739,11 @@ resource configservice_label portal_config_manager_portal_mail_templates_save_te
   product_id = resource.configservice_product.media_manager_5.id
   default_label_values = [
     {
-      default_translation = 'Email templates was saved successfully'
+      default_translation = 'Mail template was saved successfully'
       language_id = data.language.english.id
     },
     {
-      default_translation = 'E-mailskabeloner blev gemt'
+      default_translation = 'Mailskabelon blev gemt'
       language_id = data.language.danish.id
     }
   ]
@@ -1771,11 +1771,11 @@ resource configservice_label portal_config_manager_portal_mail_templates_save_te
   product_id = resource.configservice_product.media_manager_5.id
   default_label_values = [
     {
-      default_translation = 'An error occurred while saving email templates'
+      default_translation = 'An error occurred while saving the mail template'
       language_id = data.language.english.id
     },
     {
-      default_translation = 'Der opstod en fejl under lagring af e-mailskabeloner'
+      default_translation = 'Der opstod en fejl under lagring af mailskabelonen'
       language_id = data.language.danish.id
     }
   ]

--- a/MM/6.1.0/config/media_manager_5/labels/Config Manager.dcl
+++ b/MM/6.1.0/config/media_manager_5/labels/Config Manager.dcl
@@ -1733,6 +1733,54 @@ resource configservice_label portal_config_manager_portal_mail_templates_toggle_
   ]
 }
 
+resource configservice_label portal_config_manager_portal_mail_templates_save_templates_success_body {
+  key = 'PORTAL_CONFIG_MANAGER_PORTAL_MAIL_TEMPLATES_SAVE_TEMPLATES_SUCCESS_BODY'
+  group = 'Config Manager'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Email templates was saved successfully'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'E-mailskabeloner blev gemt'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label portal_config_manager_portal_mail_templates_save_templates_error_title {
+  key = 'PORTAL_CONFIG_MANAGER_PORTAL_MAIL_TEMPLATES_SAVE_TEMPLATES_ERROR_TITLE'
+  group = 'Config Manager'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Error'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Fejl'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label portal_config_manager_portal_mail_templates_save_templates_error_body {
+  key = 'PORTAL_CONFIG_MANAGER_PORTAL_MAIL_TEMPLATES_SAVE_TEMPLATES_ERROR_BODY'
+  group = 'Config Manager'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'An error occurred while saving email templates'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Der opstod en fejl under lagring af e-mailskabeloner'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
 resource configservice_label portal_config_manager_create_new_mail_template_dialog_create {
   key = 'PORTAL_CONFIG_MANAGER_CREATE_NEW_MAIL_TEMPLATE_DIALOG_CREATE'
   group = 'Config Manager'


### PR DESCRIPTION
https://digizuite.atlassian.net/browse/MM5-5155

**NOTE:** The generic messages related to saving one or multiple email templates at the same time