### PR TITLE
DDAM-8081 Add format guids for most default formats

### DIFF
--- a/DC/5.10.10/formats/audio_preview.dcl
+++ b/DC/5.10.10/formats/audio_preview.dcl
@@ -1,5 +1,6 @@
 ﻿resource format audio_preview {
     name = 'Audio Preview'
+    guid = 'cc8fbe8f-5a25-462f-8de8-b84858bae406'
     description = 'The default audio preview.'
     immediately_generated_for = [{
             asset_type = 'Audio'

--- a/DC/5.10.10/formats/large_thumbnail.dcl
+++ b/DC/5.10.10/formats/large_thumbnail.dcl
@@ -1,5 +1,6 @@
 ﻿resource format large_thumbnail {
     name = 'Large Thumbnail'
+    guid = '0a46c385-7b90-4364-bcb0-87265bcc216d'
     description = 'A large thumbnail.'
     immediately_generated_for = [{
             asset_type = 'All'

--- a/DC/5.10.10/formats/original.dcl
+++ b/DC/5.10.10/formats/original.dcl
@@ -1,5 +1,6 @@
 ﻿resource format original {
     name = 'Original'
+    guid = '283d5145-51e3-4f98-9aa1-a472fbb5e2ad'
     description = 'The original file that was uploaded.'
     immediately_generated_for = []
     download_replace_mask = '[%AssetId%]'

--- a/DC/5.10.10/formats/pdf.dcl
+++ b/DC/5.10.10/formats/pdf.dcl
@@ -1,5 +1,6 @@
 ﻿resource format pdf {
     name = 'PDF'
+    guid = 'bc7e41bd-9076-4137-b66e-111d5b8bfaf6'
     description = 'A PDF.'
     immediately_generated_for = [{
             asset_type = 'PowerPoint'

--- a/DC/5.10.10/formats/thumbnail.dcl
+++ b/DC/5.10.10/formats/thumbnail.dcl
@@ -1,5 +1,6 @@
 ﻿resource format thumbnail {
     name = 'Thumbnail'
+    guid = '88c69734-3905-4940-9e1a-851fe2ab10b8'
     description = 'The default thumbnail.'
     immediately_generated_for = [{
             asset_type = 'All'

--- a/DC/5.10.10/formats/video_preview.dcl
+++ b/DC/5.10.10/formats/video_preview.dcl
@@ -1,5 +1,6 @@
 ﻿resource format video_preview {
     name = 'Video Preview'
+    guid = '03fbf99c-feec-4382-add6-362ea5156d29'
     description = 'A video preview in 1080p.'
     immediately_generated_for = [{
             asset_type = 'Video'


### PR DESCRIPTION
Should hopefully be the same guids as here: https://github.com/Digizuite/damcenter/pull/1184

Do note: I have not added anything to "Large jpeg thumbnail" and "large png thumbnails" as we are removing those in a later version, so we probably aren't going to touch them much anyway. 