### PR TITLE
DAM-7971 Support blocking deleting assets based on relations

### DIFF
--- a/DC/6.2.0/asset_relation_types/thumbnail_replacement.dcl
+++ b/DC/6.2.0/asset_relation_types/thumbnail_replacement.dcl
@@ -11,6 +11,11 @@ resource asset_relation_type thumbnail_replacement {
                 purpose = 'LargeThumbnail'
             }]
     }
+    deletion_behavior = {
+        enable_behavior = true
+        locked_when_primary = true
+        locked_when_secondary = true
+    }	
     labels = [{
             language_id = resource.language.english.id
             label = 'Thumbnail replacement'


### PR DESCRIPTION
[DAM-7971](https://digizuite.atlassian.net/browse/DAM-7971)

related to [DAM-7971 Support blocking deleting assets based on relations](https://github.com/Digizuite/digizuite.core/pull/3167) changes

[DAM-7971]: https://digizuite.atlassian.net/browse/DAM-7971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ