### PR TITLE
DAM-8195 Asset relation: The ability to define up to 2 sets of metafields to expose in the asset relation tab (one for each relation type)

### DIFF
--- a/DC/6.2.0/asset_relation_types/derived_from.dcl
+++ b/DC/6.2.0/asset_relation_types/derived_from.dcl
@@ -3,8 +3,7 @@ resource asset_relation_type derived_from {
     name = 'Derivation'
     description = 'The secondary asset is derived from the first asset, for example as a crop or trim.'
     multiplicity = 'OneToMany'
-	show_in_list_when_primary = true
-	show_in_list_when_secondary = true
+	sync_additional_fields = true
     deletion_behavior = {
         enable_behavior = true
         inherit_soft_delete = false

--- a/DC/6.2.0/asset_relation_types/replaced_with.dcl
+++ b/DC/6.2.0/asset_relation_types/replaced_with.dcl
@@ -3,8 +3,7 @@ resource asset_relation_type replaced_with {
     name = 'Replacement'
     description = 'The secondary asset is an older version of the primary asset, usually as a result of a replacement.'
     multiplicity = 'OneToMany'
-	show_in_list_when_primary = true
-	show_in_list_when_secondary = true
+	sync_additional_fields = true
     channel_publishing_behavior = {
         enable_behavior = true
         block_publishing = true

--- a/DC/6.2.0/asset_relation_types/thumbnail_replacement.dcl
+++ b/DC/6.2.0/asset_relation_types/thumbnail_replacement.dcl
@@ -3,8 +3,7 @@ resource asset_relation_type thumbnail_replacement {
     name = 'Thumbnail replacement'
     description = 'The primary asset uses the secondary asset as its thumbnail'
     multiplicity = 'ManyToOne'
-	show_in_list_when_primary = true
-	show_in_list_when_secondary = true
+	sync_additional_fields = true
     renditions_behavior = {
         enable_behavior = true
         override_format_purposes = [{

--- a/DC/6.2.0/asset_relation_types/used_by.dcl
+++ b/DC/6.2.0/asset_relation_types/used_by.dcl
@@ -3,8 +3,7 @@ resource asset_relation_type used_by {
     name = 'Usage'
     description = 'The secondary asset is used in the first asset, for example a asset within a document'
     multiplicity = 'OneToMany'
-	show_in_list_when_primary = true
-	show_in_list_when_secondary = true
+	sync_additional_fields = true
     deletion_behavior = {
         enable_behavior = false
     }


### PR DESCRIPTION

[DAM-8195](https://digizuite.atlassian.net/browse/DAM-8195)

related to [#3198](https://github.com/Digizuite/digizuite.core/pull/3198)

[DAM-8195]: https://digizuite.atlassian.net/browse/DAM-8195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ