### PR TITLE
DAM-8145 Add labels

### DIFF
--- a/MM/6.2.0/config/media_manager_5/labels/Administration.dcl
+++ b/MM/6.2.0/config/media_manager_5/labels/Administration.dcl
@@ -13247,3 +13247,22 @@ resource configservice_label administration_tools_system_similar_search_section_
     }
   ]
 }
+
+resource configservice_label administration_tools_meta_fields_section_ignore_values_in_configuration_management {
+  key = 'ADMINISTRATION_TOOLS_META_FIELDS_SECTION_IGNORE_VALUES_IN_CONFIGURATION_MANAGEMENT'
+  group = 'administration-tools - meta-fields-section'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Ignore values in configuration management'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Ignorer værdier i configuration management'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+
+


### PR DESCRIPTION
This setting specifically controls if configuration management will manage values for fields where the values are normally always managed. See https://digizuite.atlassian.net/browse/DAM-8145 for more details. 