### PR TITLE
DAM-8098 Hide ReplacedWith and DerivedFrom secondary assets by default using relation type behavior

### DIFF
--- a/DC/6.2.0/asset_relation_types/derived_from.dcl
+++ b/DC/6.2.0/asset_relation_types/derived_from.dcl
@@ -10,6 +10,10 @@ resource asset_relation_type derived_from {
         inherit_soft_delete = false
         inherit_hard_delete = true
     }
+    search_behavior = {
+        enable_behavior = true
+        hide_secondary_by_default_in_search = true
+    }
     labels = [{
             language_id = resource.language.english.id
             label = 'Derivation'

--- a/DC/6.2.0/asset_relation_types/replaced_with.dcl
+++ b/DC/6.2.0/asset_relation_types/replaced_with.dcl
@@ -14,6 +14,10 @@ resource asset_relation_type replaced_with {
         inherit_soft_delete = false
         inherit_hard_delete = true
     }
+    search_behavior = {
+        enable_behavior = true
+        hide_secondary_by_default_in_search = true
+    }
     labels = [{
             language_id = resource.language.english.id
             label = 'Replacement'


### PR DESCRIPTION
https://digizuite.atlassian.net/browse/DAM-8098

I'm not sure which of the Hub relations this should be done for, if any?