### PR TITLE
Updated config on asset relation derived from to include the crop name in the secondary list

### DIFF
--- a/DC/6.2.0/asset_relation_types/derived_from.dcl
+++ b/DC/6.2.0/asset_relation_types/derived_from.dcl
@@ -21,6 +21,9 @@ resource asset_relation_type derived_from {
             primary_to_secondary_label = 'Derives'
             secondary_to_primary_label = 'Derived from'
         }]
+	additional_fields_when_secondary = [{
+        search_key = '${to_string(resource.string_metafield.crop_name.item_guid)}'
+    }]
 }
 
 

--- a/DC/6.2.0/asset_relation_types/derived_from.dcl
+++ b/DC/6.2.0/asset_relation_types/derived_from.dcl
@@ -21,7 +21,7 @@ resource asset_relation_type derived_from {
             primary_to_secondary_label = 'Derives'
             secondary_to_primary_label = 'Derived from'
         }]
-	additional_fields_when_secondary = [{
+    additional_fields_when_secondary = [{
         search_key = '${to_string(resource.string_metafield.crop_name.item_guid)}'
     }]
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0b158ee4-f798-4957-997d-3213f72ce471)
