### PR TITLE
bug/KK-111

### DIFF
--- a/KeyShot/6.3.0/config/media_manager_5/fields/office_connector_image_insert_quality.dcl
+++ b/KeyShot/6.3.0/config/media_manager_5/fields/office_connector_image_insert_quality.dcl
@@ -1,0 +1,12 @@
+data configservice_int_config_field office_connector_image_insert_rendition {
+    product_id = data.configservice_product.media_manager_5.id
+    group = 'Integration - Office Connector'
+    key = 'officeConnectorImageInsertRendition'
+}
+
+resource configservice_config_int_field_value default_office_connector_image_insert_rendition {
+    value = -1
+    field_id = data.configservice_int_config_field.office_connector_image_insert_rendition.id
+    portal_id = data.configservice_portal.media_manager_5.id
+    language_id = 0
+}


### PR DESCRIPTION
Changed the default insert quality to Original for the Office Connector, because KeyShot Hub doesn't have Large Thumbnail as download quality, which means the place button won't work