### PR TITLE
Revert "DAM-7993. Add role 'Can_Customize_Search_Filters_In_Frontend'…

### DIFF
--- a/DC/6.3.0/member_groups/user_type/administrator_22.dcl
+++ b/DC/6.3.0/member_groups/user_type/administrator_22.dcl
@@ -136,8 +136,6 @@ resource member_group administrator_22 {
             constant = 'Can_Live_Export_System_Data'
         }, {
             constant = 'MediaPortal_360Viewer_Embed'
-        }, {
-            constant = 'Can_Customize_Search_Filters_In_Frontend'
         }]
     autolink = {
         item_guid = '58efafcb-4ce9-43d0-b413-b842fbccb576'

--- a/DC/6.3.0/member_groups/user_type/content_creator.dcl
+++ b/DC/6.3.0/member_groups/user_type/content_creator.dcl
@@ -22,8 +22,6 @@ resource member_group content_creator {
             constant = 'Can_Live_Export_System_Data'
         }, {
             constant = 'MediaPortal_360Viewer_Embed'
-        }, {
-            constant = 'Can_Customize_Search_Filters_In_Frontend'
         }]
     autolink = {
         item_guid = 'ed672267-2724-47d7-acbe-527f875445bc'

--- a/DC/6.3.0/member_groups/user_type/light_user_24.dcl
+++ b/DC/6.3.0/member_groups/user_type/light_user_24.dcl
@@ -22,9 +22,7 @@ resource member_group light_user_24 {
             constant = 'Can_view_metadata_tab'
         }, {
             constant = 'Can_view_related_assets'
-        }, {
-             constant = 'Can_Customize_Search_Filters_In_Frontend'
-        }] 
+        }]
     autolink = {
         item_guid = 'ea2b32ef-cd90-41c8-93ac-d026881b6c12'
     }

--- a/DC/6.3.0/member_groups/user_type/super_administrator.dcl
+++ b/DC/6.3.0/member_groups/user_type/super_administrator.dcl
@@ -224,8 +224,6 @@ resource member_group super_administrator {
             constant = 'Can_Live_Export_System_Data'
         }, {
             constant = 'MediaPortal_360Viewer_Embed'
-        }, {
-            constant = 'Can_Customize_Search_Filters_In_Frontend'
         }]
     autolink = {
         item_guid = '0d8dff0a-53d5-4161-8484-aa8c1af5680d'

--- a/OOBE/6.3.0/member_groups/user_type/administrator_22.dcl
+++ b/OOBE/6.3.0/member_groups/user_type/administrator_22.dcl
@@ -155,8 +155,6 @@ patch member_group administrator_patch {
             constant = 'Can_Live_Export_System_Data'
         }, {
             constant = 'MediaPortal_360Viewer_Embed'
-        }, {
-            constant = 'Can_Customize_Search_Filters_In_Frontend'
         }]
 }
 

--- a/OOBE/6.3.0/member_groups/user_type/content_creator.dcl
+++ b/OOBE/6.3.0/member_groups/user_type/content_creator.dcl
@@ -88,8 +88,6 @@ patch member_group content_creator_patch {
             constant = 'Can_Live_Export_System_Data'
         }, {
             constant = 'MediaPortal_360Viewer_Embed'
-        }, {
-            constant = 'Can_Customize_Search_Filters_In_Frontend'
         }]
     name = 'Content creator (profile)'
 }

--- a/OOBE/6.3.0/member_groups/user_type/light_user_24.dcl
+++ b/OOBE/6.3.0/member_groups/user_type/light_user_24.dcl
@@ -52,8 +52,6 @@ patch member_group light_user_patch {
             constant = 'Saved_Searches_CRUD'
         }, {
             constant = 'MediaPortal_360Viewer_Embed'
-        }, {
-            constant = 'Can_Customize_Search_Filters_In_Frontend'
         }]
     name = 'Light user (profile)'
 }


### PR DESCRIPTION
… and assign to specific member groups (#795)"

This reverts commit 13d5610d6f11077ddf7bbb7cf12d940348e9f580.

This was accidentally added to the 6.3.0 layer.