### PR TITLE
MM5-7796: Add portal config for asset status / assignee metafields

### DIFF
--- a/MM/6.6.0/config/media_manager_5/fields/asset_status_metafield.dcl
+++ b/MM/6.6.0/config/media_manager_5/fields/asset_status_metafield.dcl
@@ -1,0 +1,10 @@
+resource configservice_string_config_field asset_status_metafield {
+    default_value = resource.combovalue_metafield.options_status.item_guid
+    type = 'MetaField'
+    product_id = resource.configservice_product.media_manager_5.id
+    group = 'default'
+    key = 'assetStatusMetafield'
+    title = 'Asset status metafield'
+    description = 'Combo metafield used to track the status of an asset in the status change dialog.'
+    meta_field_type = 'ComboValue'
+}

--- a/MM/6.6.0/config/media_manager_5/fields/asset_status_owner_metafield.dcl
+++ b/MM/6.6.0/config/media_manager_5/fields/asset_status_owner_metafield.dcl
@@ -1,0 +1,10 @@
+resource configservice_string_config_field asset_status_owner_metafield {
+    default_value = resource.masteritem_reference_metafield.options_owner.item_guid
+    type = 'MetaField'
+    product_id = resource.configservice_product.media_manager_5.id
+    group = 'default'
+    key = 'assetStatusOwnerMetafield'
+    title = 'Asset status owner metafield'
+    description = 'Master item reference metafield used to assign a user (owner) when changing asset status.'
+    meta_field_type = 'MasterItemReference'
+}

--- a/MM/6.7.0/config/media_manager_5/fields/asset_status_metafield.dcl
+++ b/MM/6.7.0/config/media_manager_5/fields/asset_status_metafield.dcl
@@ -1,0 +1,10 @@
+resource configservice_string_config_field asset_status_metafield {
+    default_value = resource.combovalue_metafield.options_status.item_guid
+    type = 'MetaField'
+    product_id = resource.configservice_product.media_manager_5.id
+    group = 'default'
+    key = 'assetStatusMetafield'
+    title = 'Asset status metafield'
+    description = 'Combo metafield used to track the status of an asset in the status change dialog.'
+    meta_field_type = 'ComboValue'
+}

--- a/MM/6.7.0/config/media_manager_5/fields/asset_status_owner_metafield.dcl
+++ b/MM/6.7.0/config/media_manager_5/fields/asset_status_owner_metafield.dcl
@@ -1,0 +1,10 @@
+resource configservice_string_config_field asset_status_owner_metafield {
+    default_value = resource.masteritem_reference_metafield.options_owner.item_guid
+    type = 'MetaField'
+    product_id = resource.configservice_product.media_manager_5.id
+    group = 'default'
+    key = 'assetStatusOwnerMetafield'
+    title = 'Asset status owner metafield'
+    description = 'Master item reference metafield used to assign a user (owner) when changing asset status.'
+    meta_field_type = 'MasterItemReference'
+}


### PR DESCRIPTION
## Summary

Adds two new Portal Configuration fields so the metafields used by the asset status change dialog can be configured per-portal instead of being hard-coded on the frontend.

- `assetStatusMetafield` — ComboValue metafield used for the asset Status dropdown
- `assetStatusOwnerMetafield` — MasterItemReference metafield used for the Assignee/Owner picker

Defaults reference the existing `options_status` / `options_owner` metafields so behavior is preserved for portals that don't override the values (no breaking change).

## Files added

- `MM/6.6.0/config/media_manager_5/fields/asset_status_metafield.dcl`
- `MM/6.6.0/config/media_manager_5/fields/asset_status_owner_metafield.dcl`
- `MM/6.7.0/config/media_manager_5/fields/asset_status_metafield.dcl`
- `MM/6.7.0/config/media_manager_5/fields/asset_status_owner_metafield.dcl`

## Related

- Jira: [MM5-7796](https://keyshot.atlassian.net/browse/MM5-7796)
- Frontend changes: separate PR in the mm5 repo (consumes these fields via `CoreConfigResponse`, with fallback to the existing hard-coded GUIDs if config is missing)

[MM5-7796]: https://keyshot.atlassian.net/browse/MM5-7796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ