### PR TITLE
DAM-9094 Ensured that the asset streamer URLs returned when getting a…

### DIFF
--- a/Cloud Storage/6.6.0/options/assetstreamersettings_custombaseurl.dcl
+++ b/Cloud Storage/6.6.0/options/assetstreamersettings_custombaseurl.dcl
@@ -1,0 +1,5 @@
+resource changeable_configuration_string_configuration_option assetstreamersettings_custombaseurl {
+    value = variable.base_api_url
+    id = 'AssetStreamerSettings:CustomBaseUrl'
+}
+

--- a/Cloud Storage/6.6.0/options/assetstreamersettings_omitdigizuitecorefromurls.dcl
+++ b/Cloud Storage/6.6.0/options/assetstreamersettings_omitdigizuitecorefromurls.dcl
@@ -1,0 +1,5 @@
+resource changeable_configuration_bit_configuration_option assetstreamersettings_omitdigizuitecorefromurls {
+    value = true
+    id = 'AssetStreamerSettings:OmitDigizuiteCoreFromUrls'
+}
+

--- a/Cloud Storage/6.6.0/options/assetstreamersettings_usebackwardcompatiblelegacyservicename.dcl
+++ b/Cloud Storage/6.6.0/options/assetstreamersettings_usebackwardcompatiblelegacyservicename.dcl
@@ -1,0 +1,5 @@
+resource changeable_configuration_bit_configuration_option assetstreamersettings_usebackwardcompatiblelegacyservicename {
+    value = false
+    id = 'AssetStreamerSettings:UseBackwardCompatibleLegacyServiceName'
+}
+

--- a/Cloud Storage/6.6.0/variables.dcl
+++ b/Cloud Storage/6.6.0/variables.dcl
@@ -7,3 +7,8 @@ variable environment_type {
     type = "string"
     description = "The type of the environment. Either 'dev', 'staging', or 'prod'"
 }
+
+variable base_api_url {
+    type = "string"
+    description = "The keyshot.com base API URL to use when constructing asset streamer URLs"
+}

--- a/Cloud Storage/6.7.0/options/assetstreamersettings_custombaseurl.dcl
+++ b/Cloud Storage/6.7.0/options/assetstreamersettings_custombaseurl.dcl
@@ -1,0 +1,5 @@
+resource changeable_configuration_string_configuration_option assetstreamersettings_custombaseurl {
+    value = variable.base_api_url
+    id = 'AssetStreamerSettings:CustomBaseUrl'
+}
+

--- a/Cloud Storage/6.7.0/options/assetstreamersettings_omitdigizuitecorefromurls.dcl
+++ b/Cloud Storage/6.7.0/options/assetstreamersettings_omitdigizuitecorefromurls.dcl
@@ -1,0 +1,5 @@
+resource changeable_configuration_bit_configuration_option assetstreamersettings_omitdigizuitecorefromurls {
+    value = true
+    id = 'AssetStreamerSettings:OmitDigizuiteCoreFromUrls'
+}
+

--- a/Cloud Storage/6.7.0/options/assetstreamersettings_usebackwardcompatiblelegacyservicename.dcl
+++ b/Cloud Storage/6.7.0/options/assetstreamersettings_usebackwardcompatiblelegacyservicename.dcl
@@ -1,0 +1,5 @@
+resource changeable_configuration_bit_configuration_option assetstreamersettings_usebackwardcompatiblelegacyservicename {
+    value = false
+    id = 'AssetStreamerSettings:UseBackwardCompatibleLegacyServiceName'
+}
+

--- a/Cloud Storage/6.7.0/variables.dcl
+++ b/Cloud Storage/6.7.0/variables.dcl
@@ -7,3 +7,8 @@ variable environment_type {
     type = "string"
     description = "The type of the environment. Either 'dev', 'staging', or 'prod'"
 }
+
+variable base_api_url {
+    type = "string"
+    description = "The keyshot.com base API URL to use when constructing asset streamer URLs"
+}


### PR DESCRIPTION
…nd searching for assets use the keyshot.com API URL, do not include /DigizuiteCore, and use AssetService instead of LegacyService