### PR TITLE
MM5-4949 Remove orphaned SELECTED_ASSETS_OVERLAY_OPTIONS_GROUP_EDIT label (6.6 / 6.7)

### DIFF
--- a/MM/6.6.0/config/media_manager_5/labels/Z Misc Labels.dcl
+++ b/MM/6.6.0/config/media_manager_5/labels/Z Misc Labels.dcl
@@ -462,22 +462,6 @@ resource configservice_label selected_assets_overlay_options_multi_insert_invali
   ]
 }
 
-resource configservice_label selected_assets_overlay_options_group_edit {
-  key = 'SELECTED_ASSETS_OVERLAY_OPTIONS_GROUP_EDIT'
-  group = 'Z Misc Labels'
-  product_id = resource.configservice_product.media_manager_5.id
-  default_label_values = [
-    {
-      default_translation = 'Group Edit'
-      language_id = data.language.english.id
-    },
-    {
-      default_translation = 'Gruppe-rediger'
-      language_id = data.language.danish.id
-    }
-  ]
-}
-
 resource configservice_label selected_assets_overlay_options_download {
   key = 'SELECTED_ASSETS_OVERLAY_OPTIONS_DOWNLOAD'
   group = 'Z Misc Labels'

--- a/MM/6.7.0/config/media_manager_5/labels/Z Misc Labels.dcl
+++ b/MM/6.7.0/config/media_manager_5/labels/Z Misc Labels.dcl
@@ -462,22 +462,6 @@ resource configservice_label selected_assets_overlay_options_multi_insert_invali
   ]
 }
 
-resource configservice_label selected_assets_overlay_options_group_edit {
-  key = 'SELECTED_ASSETS_OVERLAY_OPTIONS_GROUP_EDIT'
-  group = 'Z Misc Labels'
-  product_id = resource.configservice_product.media_manager_5.id
-  default_label_values = [
-    {
-      default_translation = 'Group Edit'
-      language_id = data.language.english.id
-    },
-    {
-      default_translation = 'Gruppe-rediger'
-      language_id = data.language.danish.id
-    }
-  ]
-}
-
 resource configservice_label selected_assets_overlay_options_download {
   key = 'SELECTED_ASSETS_OVERLAY_OPTIONS_DOWNLOAD'
   group = 'Z Misc Labels'


### PR DESCRIPTION
## Summary
- Removes the `SELECTED_ASSETS_OVERLAY_OPTIONS_GROUP_EDIT` label resource from `MM/6.6.0` and `MM/6.7.0` (in `config/media_manager_5/labels/Z Misc Labels.dcl`).
- Follow-up to the removal of the `groupEdit` feature in mm5 (keyshot-dev/mm5#7626 area / release/6.6.0). With the last code reference gone, the label resource is dead config.

## Scope
- Only `6.6.0` and `6.7.0`. Older version folders (5.x, 6.0.x–6.5.x) intentionally untouched — they're released.
- No other labels in the file are modified.

## Test plan
- [ ] CI passes on this branch.
- [ ] `grep -r 'SELECTED_ASSETS_OVERLAY_OPTIONS_GROUP_EDIT' MM/6.6.0 MM/6.7.0` returns zero hits.
- [ ] `grep -r 'SELECTED_ASSETS_OVERLAY_OPTIONS_GROUP_EDIT' MM/6.5.2` still returns the label (historical version untouched).