### PR TITLE
DAM-9294 Support `Hidden` and `HasFullWorkspaceAccess` properties on workspace member

### DIFF
--- a/Cloud Storage/6.6.0/members/guest.dcl
+++ b/Cloud Storage/6.6.0/members/guest.dcl
@@ -11,4 +11,6 @@ patch workspace_member guest {
     folder_id = data.member_folder.system_users.id
     groups = []
     roles = []
+	hidden = true
+	has_full_workspace_access = false
 }

--- a/Cloud Storage/6.6.0/members/superadministrator.dcl
+++ b/Cloud Storage/6.6.0/members/superadministrator.dcl
@@ -1,0 +1,13 @@
+data member superadministrator {
+    username = 'SuperAdministrator'
+}
+
+data workspace_member superadministrator {
+    member_id = data.member.superadministrator.member_id
+}
+
+patch workspace_member superadministrator {
+    target = data.workspace_member.superadministrator
+	hidden = true
+	has_full_workspace_access = true
+}

--- a/Cloud Storage/6.6.0/members/system.dcl
+++ b/Cloud Storage/6.6.0/members/system.dcl
@@ -1,0 +1,13 @@
+data member system {
+    username = 'System'
+}
+
+data workspace_member system {
+    member_id = data.member.system.member_id
+}
+
+patch workspace_member system {
+    target = data.workspace_member.system
+	hidden = true
+	has_full_workspace_access = true
+}

--- a/Cloud Storage/6.7.0/members/guest.dcl
+++ b/Cloud Storage/6.7.0/members/guest.dcl
@@ -11,4 +11,6 @@ patch workspace_member guest {
     folder_id = data.member_folder.system_users.id
     groups = []
     roles = []
+    hidden = true
+	has_full_workspace_access = false
 }

--- a/Cloud Storage/6.7.0/members/superadministrator.dcl
+++ b/Cloud Storage/6.7.0/members/superadministrator.dcl
@@ -1,0 +1,13 @@
+data member superadministrator {
+    username = 'SuperAdministrator'
+}
+
+data workspace_member superadministrator {
+    member_id = data.member.superadministrator.member_id
+}
+
+patch workspace_member superadministrator {
+    target = data.workspace_member.superadministrator
+	hidden = true
+	has_full_workspace_access = true
+}

--- a/Cloud Storage/6.7.0/members/system.dcl
+++ b/Cloud Storage/6.7.0/members/system.dcl
@@ -1,0 +1,13 @@
+data member system {
+    username = 'System'
+}
+
+data workspace_member system {
+    member_id = data.member.system.member_id
+}
+
+patch workspace_member system {
+    target = data.workspace_member.system
+	hidden = true
+	has_full_workspace_access = true
+}


### PR DESCRIPTION
[DAM-9294](https://keyshot.atlassian.net/browse/DAM-9294)

related to [#4312](https://github.com/keyshot-dev/digizuite.core/pull/4312)


[DAM-9294]: https://keyshot.atlassian.net/browse/DAM-9294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ