### PR TITLE
MM5-8050 add labels for recalculate inheritance + spread indicator

### DIFF
--- a/MM/6.6.0/config/media_manager_5/labels/Administration.dcl
+++ b/MM/6.6.0/config/media_manager_5/labels/Administration.dcl
@@ -12562,6 +12562,86 @@ resource configservice_label administration_tools_system_asset_relation_types_in
   ]
 }
 
+resource configservice_label administration_tools_system_asset_relation_types_recalculate_inheritance {
+  key = 'ADMINISTRATION_TOOLS_SYSTEM_ASSET_RELATION_TYPES_RECALCULATE_INHERITANCE'
+  group = 'administration-tools - system - asset-relation-types'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Recalculate inheritance'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Genberegn nedarvning'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label administration_tools_system_asset_relation_types_recalculate_inheritance_tooltip {
+  key = 'ADMINISTRATION_TOOLS_SYSTEM_ASSET_RELATION_TYPES_RECALCULATE_INHERITANCE_TOOLTIP'
+  group = 'administration-tools - system - asset-relation-types'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Manually recalculate inherited metadata values for all assets using this relation type. Useful after changing which fields are inherited.'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Genberegn manuelt nedarvede metadataværdier for alle assets, der bruger denne relationstype. Nyttigt efter ændring af hvilke felter der nedarves.'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label administration_tools_system_asset_relation_types_recalculate_inheritance_success {
+  key = 'ADMINISTRATION_TOOLS_SYSTEM_ASSET_RELATION_TYPES_RECALCULATE_INHERITANCE_SUCCESS'
+  group = 'administration-tools - system - asset-relation-types'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Inheritance recalculation started'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Genberegning af nedarvning er startet'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label administration_tools_system_asset_relation_types_recalculate_inheritance_error_title {
+  key = 'ADMINISTRATION_TOOLS_SYSTEM_ASSET_RELATION_TYPES_RECALCULATE_INHERITANCE_ERROR_TITLE'
+  group = 'administration-tools - system - asset-relation-types'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Could not recalculate inheritance'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Kunne ikke genberegne nedarvning'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label administration_tools_system_asset_relation_types_recalculate_inheritance_error_body {
+  key = 'ADMINISTRATION_TOOLS_SYSTEM_ASSET_RELATION_TYPES_RECALCULATE_INHERITANCE_ERROR_BODY'
+  group = 'administration-tools - system - asset-relation-types'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = '{{ error }}'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = '{{ error }}'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
 resource configservice_label administration_tools_system_workspaces_section {
   key = 'ADMINISTRATION_TOOLS_SYSTEM_WORKSPACES_SECTION'
   group = 'administration-tools - system - workspaces'

--- a/MM/6.6.0/config/media_manager_5/labels/Metadata.dcl
+++ b/MM/6.6.0/config/media_manager_5/labels/Metadata.dcl
@@ -1955,11 +1955,11 @@ resource configservice_label multi_metadata_editor_field_spreads_tooltip {
   product_id = resource.configservice_product.media_manager_5.id
   default_label_values = [
     {
-      default_translation = 'Changing this field will spread the update to linked assets'
+      default_translation = 'The value of this metafield is inherited by at least one related asset'
       language_id = data.language.english.id
     },
     {
-      default_translation = 'Ændring af dette felt vil sprede opdateringen til tilknyttede assets'
+      default_translation = 'Værdien af dette metadatafelt nedarves af mindst ét relateret asset'
       language_id = data.language.danish.id
     }
   ]

--- a/MM/6.6.0/config/media_manager_5/labels/Metadata.dcl
+++ b/MM/6.6.0/config/media_manager_5/labels/Metadata.dcl
@@ -1949,6 +1949,22 @@ resource configservice_label multi_metadata_editor_field_inherited_tooltip {
   ]
 }
 
+resource configservice_label multi_metadata_editor_field_spreads_tooltip {
+  key = 'MULTI_METADATA_EDITOR_FIELD_SPREADS_TOOLTIP'
+  group = 'Metadata'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Changing this field will spread the update to linked assets'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Ændring af dette felt vil sprede opdateringen til tilknyttede assets'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
 resource configservice_label multi_metadata_editor_search_metadata_placeholder {
   key = 'MULTI_METADATA_EDITOR_SEARCH_METADATA_PLACEHOLDER'
   group = 'Metadata'

--- a/MM/6.7.0/config/media_manager_5/labels/Administration.dcl
+++ b/MM/6.7.0/config/media_manager_5/labels/Administration.dcl
@@ -12562,6 +12562,86 @@ resource configservice_label administration_tools_system_asset_relation_types_in
   ]
 }
 
+resource configservice_label administration_tools_system_asset_relation_types_recalculate_inheritance {
+  key = 'ADMINISTRATION_TOOLS_SYSTEM_ASSET_RELATION_TYPES_RECALCULATE_INHERITANCE'
+  group = 'administration-tools - system - asset-relation-types'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Recalculate inheritance'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Genberegn nedarvning'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label administration_tools_system_asset_relation_types_recalculate_inheritance_tooltip {
+  key = 'ADMINISTRATION_TOOLS_SYSTEM_ASSET_RELATION_TYPES_RECALCULATE_INHERITANCE_TOOLTIP'
+  group = 'administration-tools - system - asset-relation-types'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Manually recalculate inherited metadata values for all assets using this relation type. Useful after changing which fields are inherited.'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Genberegn manuelt nedarvede metadataværdier for alle assets, der bruger denne relationstype. Nyttigt efter ændring af hvilke felter der nedarves.'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label administration_tools_system_asset_relation_types_recalculate_inheritance_success {
+  key = 'ADMINISTRATION_TOOLS_SYSTEM_ASSET_RELATION_TYPES_RECALCULATE_INHERITANCE_SUCCESS'
+  group = 'administration-tools - system - asset-relation-types'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Inheritance recalculation started'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Genberegning af nedarvning er startet'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label administration_tools_system_asset_relation_types_recalculate_inheritance_error_title {
+  key = 'ADMINISTRATION_TOOLS_SYSTEM_ASSET_RELATION_TYPES_RECALCULATE_INHERITANCE_ERROR_TITLE'
+  group = 'administration-tools - system - asset-relation-types'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Could not recalculate inheritance'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Kunne ikke genberegne nedarvning'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label administration_tools_system_asset_relation_types_recalculate_inheritance_error_body {
+  key = 'ADMINISTRATION_TOOLS_SYSTEM_ASSET_RELATION_TYPES_RECALCULATE_INHERITANCE_ERROR_BODY'
+  group = 'administration-tools - system - asset-relation-types'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = '{{ error }}'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = '{{ error }}'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
 resource configservice_label administration_tools_system_asset_relation_types_auto_relate_title {
   key = 'ADMINISTRATION_TOOLS_SYSTEM_ASSET_RELATION_TYPES_AUTO_RELATE_TITLE'
   group = 'administration-tools - system - asset-relation-types'

--- a/MM/6.7.0/config/media_manager_5/labels/Metadata.dcl
+++ b/MM/6.7.0/config/media_manager_5/labels/Metadata.dcl
@@ -1955,11 +1955,11 @@ resource configservice_label multi_metadata_editor_field_spreads_tooltip {
   product_id = resource.configservice_product.media_manager_5.id
   default_label_values = [
     {
-      default_translation = 'Changing this field will spread the update to linked assets'
+      default_translation = 'The value of this metafield is inherited by at least one related asset'
       language_id = data.language.english.id
     },
     {
-      default_translation = 'Ændring af dette felt vil sprede opdateringen til tilknyttede assets'
+      default_translation = 'Værdien af dette metadatafelt nedarves af mindst ét relateret asset'
       language_id = data.language.danish.id
     }
   ]

--- a/MM/6.7.0/config/media_manager_5/labels/Metadata.dcl
+++ b/MM/6.7.0/config/media_manager_5/labels/Metadata.dcl
@@ -1949,6 +1949,22 @@ resource configservice_label multi_metadata_editor_field_inherited_tooltip {
   ]
 }
 
+resource configservice_label multi_metadata_editor_field_spreads_tooltip {
+  key = 'MULTI_METADATA_EDITOR_FIELD_SPREADS_TOOLTIP'
+  group = 'Metadata'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Changing this field will spread the update to linked assets'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Ændring af dette felt vil sprede opdateringen til tilknyttede assets'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
 resource configservice_label multi_metadata_editor_search_metadata_placeholder {
   key = 'MULTI_METADATA_EDITOR_SEARCH_METADATA_PLACEHOLDER'
   group = 'Metadata'


### PR DESCRIPTION
## Summary

Adds 6 new translation labels (mirrored in MM/6.6.0 and MM/6.7.0) for the second half of MM5-8050 UI:

**Part 4 — Inheritance spread indicator** (metadata editor):
- `MULTI_METADATA_EDITOR_FIELD_SPREADS_TOOLTIP` — tooltip shown on the spread icon next to a metafield when changing its value will propagate to linked assets

**Part 5 — Recalculate inheritance button** (asset relation type admin):
- `ADMINISTRATION_TOOLS_SYSTEM_ASSET_RELATION_TYPES_RECALCULATE_INHERITANCE` — button label
- `..._RECALCULATE_INHERITANCE_TOOLTIP` — button hover tooltip explaining when it's useful
- `..._RECALCULATE_INHERITANCE_SUCCESS` — notification on successful trigger
- `..._RECALCULATE_INHERITANCE_ERROR_TITLE` / `..._RECALCULATE_INHERITANCE_ERROR_BODY` — error notification

English + Danish defaults included. Please review the Danish translations — I'm not a native speaker.

Paired with the mm5 frontend PR for MM5-8050 (consumes these labels). Requires backend release/6.6.0 (digizuite.core `cb3fc71bdf` — `DAM-8264 Metadata feedback`) to be deployed before the spread indicator and recalculate endpoint actually work.

## Test plan
- [ ] Import the layer into a dev environment with backend release/6.6.0
- [ ] Verify all 6 keys resolve in the UI (no raw `ADMINISTRATION_TOOLS_…` / `MULTI_METADATA_EDITOR_…` strings)
- [ ] Switch language to Danish and verify renderings

🤖 Generated with [Claude Code](https://claude.com/claude-code)