### PR TITLE
DAM-9341 Remove multi-file-upload-presets from the base MM layer

### DIFF
--- a/MM/6.6.0/multi_file_upload_presets/id_360_images.dcl
+++ b/MM/6.6.0/multi_file_upload_presets/id_360_images.dcl
@@ -1,9 +1,0 @@
-resource multi_file_upload_preset id_360_images {
-    name = '360 Images'
-    asset_relation_type_guids = [{
-            asset_relation_type = resource.asset_relation_type.id_360_images.guid
-        }]
-    use_meta_asset_as_primary = true
-    portal_id = 0
-    system = true
-}

--- a/MM/6.7.0/multi_file_upload_presets/id_360_images.dcl
+++ b/MM/6.7.0/multi_file_upload_presets/id_360_images.dcl
@@ -1,9 +1,0 @@
-resource multi_file_upload_preset id_360_images {
-    name = '360 Images'
-    asset_relation_type_guids = [{
-            asset_relation_type = resource.asset_relation_type.id_360_images.guid
-        }]
-    use_meta_asset_as_primary = true
-    portal_id = 0
-    system = true
-}


### PR DESCRIPTION
https://keyshot.atlassian.net/browse/DAM-9341

It isn't supported in non-default workspaces, and we can always add it in a custom layer if needed.