### PR TITLE
MM5-7867 Audit trail: metadata update source labels

### DIFF
--- a/MM/6.6.1/config/media_manager_5/labels/Audit Trail.dcl
+++ b/MM/6.6.1/config/media_manager_5/labels/Audit Trail.dcl
@@ -1296,3 +1296,98 @@ resource configservice_label audit_trail_asset_folder_changed_summary {
   ]
 }
 
+resource configservice_label audit_trail_metadata_copied_summary {
+  key = 'AUDIT_TRAIL_METADATA_COPIED_SUMMARY'
+  group = 'Audit Trail'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Metadata copied'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Metadata kopieret'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label audit_trail_metadata_inherited_summary {
+  key = 'AUDIT_TRAIL_METADATA_INHERITED_SUMMARY'
+  group = 'Audit Trail'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Metadata inherited'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Metadata nedarvet'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label audit_trail_metadata_update_source {
+  key = 'AUDIT_TRAIL_METADATA_UPDATE_SOURCE'
+  group = 'Audit Trail'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Update source'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Opdateringskilde'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label audit_trail_metadata_update_source_regular {
+  key = 'AUDIT_TRAIL_METADATA_UPDATE_SOURCE_REGULAR'
+  group = 'Audit Trail'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Regular change'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Almindelig ændring'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label audit_trail_metadata_update_source_copy {
+  key = 'AUDIT_TRAIL_METADATA_UPDATE_SOURCE_COPY'
+  group = 'Audit Trail'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Metadata copy'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Metadata-kopi'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label audit_trail_metadata_update_source_inherited {
+  key = 'AUDIT_TRAIL_METADATA_UPDATE_SOURCE_INHERITED'
+  group = 'Audit Trail'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Inheritance'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Nedarvning'
+      language_id = data.language.danish.id
+    }
+  ]
+}

--- a/MM/6.7.0/config/media_manager_5/labels/Audit Trail.dcl
+++ b/MM/6.7.0/config/media_manager_5/labels/Audit Trail.dcl
@@ -1296,3 +1296,98 @@ resource configservice_label audit_trail_asset_folder_changed_summary {
   ]
 }
 
+resource configservice_label audit_trail_metadata_copied_summary {
+  key = 'AUDIT_TRAIL_METADATA_COPIED_SUMMARY'
+  group = 'Audit Trail'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Metadata copied'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Metadata kopieret'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label audit_trail_metadata_inherited_summary {
+  key = 'AUDIT_TRAIL_METADATA_INHERITED_SUMMARY'
+  group = 'Audit Trail'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Metadata inherited'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Metadata nedarvet'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label audit_trail_metadata_update_source {
+  key = 'AUDIT_TRAIL_METADATA_UPDATE_SOURCE'
+  group = 'Audit Trail'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Update source'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Opdateringskilde'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label audit_trail_metadata_update_source_regular {
+  key = 'AUDIT_TRAIL_METADATA_UPDATE_SOURCE_REGULAR'
+  group = 'Audit Trail'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Regular change'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Almindelig ændring'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label audit_trail_metadata_update_source_copy {
+  key = 'AUDIT_TRAIL_METADATA_UPDATE_SOURCE_COPY'
+  group = 'Audit Trail'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Metadata copy'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Metadata-kopi'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label audit_trail_metadata_update_source_inherited {
+  key = 'AUDIT_TRAIL_METADATA_UPDATE_SOURCE_INHERITED'
+  group = 'Audit Trail'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Inheritance'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Nedarvning'
+      language_id = data.language.danish.id
+    }
+  ]
+}


### PR DESCRIPTION
## MM5-7867 — Audit trail: include reason for metadata log entry

Adds the translation labels needed to surface the **source** of a metadata change in the audit trail (regular change / metadata copy / inheritance), backing the frontend work in the [mm5](https://github.com/keyshot-dev/mm5) repo (ticket [MM5-7867](https://keyshot.atlassian.net/browse/MM5-7867)).

### New labels (group `Audit Trail`)
| Key | EN | DA |
| --- | --- | --- |
| `AUDIT_TRAIL_METADATA_COPIED_SUMMARY` | Metadata copied | Metadata kopieret |
| `AUDIT_TRAIL_METADATA_INHERITED_SUMMARY` | Metadata inherited | Metadata nedarvet |
| `AUDIT_TRAIL_METADATA_UPDATE_SOURCE` | Update source | Opdateringskilde |
| `AUDIT_TRAIL_METADATA_UPDATE_SOURCE_REGULAR` | Regular change | Almindelig ændring |
| `AUDIT_TRAIL_METADATA_UPDATE_SOURCE_COPY` | Metadata copy | Metadata-kopi |
| `AUDIT_TRAIL_METADATA_UPDATE_SOURCE_INHERITED` | Inheritance | Nedarvning |

### Versions
Added identically to:
- `MM/6.6.1/config/media_manager_5/labels/Audit Trail.dcl`
- `MM/6.7.0/config/media_manager_5/labels/Audit Trail.dcl`

Both files remain byte-identical after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MM5-7867]: https://keyshot.atlassian.net/browse/MM5-7867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ