### PR TITLE
MM5-8048 Add focal point changed audit trail labels

### DIFF
--- a/MM/6.6.1/config/media_manager_5/labels/Audit Trail.dcl
+++ b/MM/6.6.1/config/media_manager_5/labels/Audit Trail.dcl
@@ -1391,3 +1391,51 @@ resource configservice_label audit_trail_metadata_update_source_inherited {
     }
   ]
 }
+
+resource configservice_label audit_trail_asset_focal_point_changed_summary {
+  key = 'AUDIT_TRAIL_ASSET_FOCAL_POINT_CHANGED_SUMMARY'
+  group = 'Audit Trail'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Focal point changed'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Fokuspunkt ændret'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label audit_trail_column_old_focal_point {
+  key = 'AUDIT_TRAIL_COLUMN_OLD_FOCAL_POINT'
+  group = 'Audit Trail'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Previous focal point'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Forrige fokuspunkt'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label audit_trail_column_new_focal_point {
+  key = 'AUDIT_TRAIL_COLUMN_NEW_FOCAL_POINT'
+  group = 'Audit Trail'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'New focal point'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Nyt fokuspunkt'
+      language_id = data.language.danish.id
+    }
+  ]
+}

--- a/MM/6.7.0/config/media_manager_5/labels/Audit Trail.dcl
+++ b/MM/6.7.0/config/media_manager_5/labels/Audit Trail.dcl
@@ -1391,3 +1391,51 @@ resource configservice_label audit_trail_metadata_update_source_inherited {
     }
   ]
 }
+
+resource configservice_label audit_trail_asset_focal_point_changed_summary {
+  key = 'AUDIT_TRAIL_ASSET_FOCAL_POINT_CHANGED_SUMMARY'
+  group = 'Audit Trail'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Focal point changed'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Fokuspunkt ændret'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label audit_trail_column_old_focal_point {
+  key = 'AUDIT_TRAIL_COLUMN_OLD_FOCAL_POINT'
+  group = 'Audit Trail'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Previous focal point'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Forrige fokuspunkt'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label audit_trail_column_new_focal_point {
+  key = 'AUDIT_TRAIL_COLUMN_NEW_FOCAL_POINT'
+  group = 'Audit Trail'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'New focal point'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Nyt fokuspunkt'
+      language_id = data.language.danish.id
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds Configuration Management labels for the new **AssetFocalPointChanged** audit trail event (introduced in DAM-9072), so MM5 displays it nicely instead of the raw `$type`.

New labels (English + Danish), added **mirrored** to both `MM/6.6.1` and `MM/6.7.0`:

- `AUDIT_TRAIL_ASSET_FOCAL_POINT_CHANGED_SUMMARY` - "Focal point changed" / "Fokuspunkt ændret"
- `AUDIT_TRAIL_COLUMN_OLD_FOCAL_POINT` - "Previous focal point" / "Forrige fokuspunkt"
- `AUDIT_TRAIL_COLUMN_NEW_FOCAL_POINT` - "New focal point" / "Nyt fokuspunkt"

## Related

- MM5-8048 (UI handling of the event)
- DAM-9072 (backend audit trail event)
