### PR TITLE
MM5-8097 Getting Started config field and labels

### DIFF
--- a/MM/6.6.1/config/media_manager_5/fields/getting_started.dcl
+++ b/MM/6.6.1/config/media_manager_5/fields/getting_started.dcl
@@ -1,0 +1,8 @@
+resource configservice_bit_config_field getting_started {
+    default_value = true
+    product_id = resource.configservice_product.media_manager_5.id
+    group = 'Intro screen'
+    key = 'gettingStarted'
+    title = 'Getting started'
+    description = 'If this is enabled, users with no folders will see Getting Started guidance for creating a folder and uploading assets.'
+}

--- a/MM/6.6.1/config/media_manager_5/labels/Asset List.dcl
+++ b/MM/6.6.1/config/media_manager_5/labels/Asset List.dcl
@@ -2874,7 +2874,7 @@ resource configservice_label asset_list_getting_started_folders_description {
       language_id = data.language.english.id
     },
     {
-      default_translation = 'Opret en mappe for at organisere dine aktiver, eller træk og slip en mappe fra din computer — dens struktur bliver gengivet automatisk.'
+      default_translation = 'Opret en mappe for at organisere dine assets, eller træk og slip en mappe fra din computer — dens struktur bliver gengivet automatisk.'
       language_id = data.language.danish.id
     }
   ]
@@ -2906,7 +2906,7 @@ resource configservice_label asset_list_getting_started_assets_title {
       language_id = data.language.english.id
     },
     {
-      default_translation = 'Ingen aktiver endnu'
+      default_translation = 'Ingen assets endnu'
       language_id = data.language.danish.id
     }
   ]
@@ -2922,7 +2922,7 @@ resource configservice_label asset_list_getting_started_assets_description {
       language_id = data.language.english.id
     },
     {
-      default_translation = 'Træk og slip filer her for at uploade, eller klik nedenfor for at gennemse. Slipper du en mappe, gengives dens struktur, og alle aktiver i den importeres.'
+      default_translation = 'Træk og slip filer her for at uploade, eller klik nedenfor for at gennemse. Slipper du en mappe, gengives dens struktur, og alle filer i den importeres.'
       language_id = data.language.danish.id
     }
   ]
@@ -2938,7 +2938,7 @@ resource configservice_label asset_list_getting_started_upload_assets {
       language_id = data.language.english.id
     },
     {
-      default_translation = 'Upload aktiver'
+      default_translation = 'Upload assets'
       language_id = data.language.danish.id
     }
   ]

--- a/MM/6.6.1/config/media_manager_5/labels/Asset List.dcl
+++ b/MM/6.6.1/config/media_manager_5/labels/Asset List.dcl
@@ -2848,3 +2848,114 @@ resource configservice_label asset_list_list_deleted_asset {
     }
   ]
 }
+resource configservice_label asset_list_getting_started_folders_title {
+  key = 'ASSET_LIST_GETTING_STARTED_FOLDERS_TITLE'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'No folders yet'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Ingen mapper endnu'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label asset_list_getting_started_folders_description {
+  key = 'ASSET_LIST_GETTING_STARTED_FOLDERS_DESCRIPTION'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Create a folder to organise your assets, or drag and drop a folder from your computer — its structure will be replicated automatically.'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Opret en mappe for at organisere dine aktiver, eller træk og slip en mappe fra din computer — dens struktur bliver gengivet automatisk.'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label asset_list_getting_started_create_folder {
+  key = 'ASSET_LIST_GETTING_STARTED_CREATE_FOLDER'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Create a folder'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Opret en mappe'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label asset_list_getting_started_assets_title {
+  key = 'ASSET_LIST_GETTING_STARTED_ASSETS_TITLE'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'No assets yet'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Ingen aktiver endnu'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label asset_list_getting_started_assets_description {
+  key = 'ASSET_LIST_GETTING_STARTED_ASSETS_DESCRIPTION'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Drag and drop files here to upload, or click below to browse. Dropping a folder will replicate its structure and import all assets inside.'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Træk og slip filer her for at uploade, eller klik nedenfor for at gennemse. Slipper du en mappe, gengives dens struktur, og alle aktiver i den importeres.'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label asset_list_getting_started_upload_assets {
+  key = 'ASSET_LIST_GETTING_STARTED_UPLOAD_ASSETS'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Upload assets'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Upload aktiver'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label asset_list_getting_started_dismiss_tooltip {
+  key = 'ASSET_LIST_GETTING_STARTED_DISMISS_TOOLTIP'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Dismiss'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Afvis'
+      language_id = data.language.danish.id
+    }
+  ]
+}

--- a/MM/6.6.2/config/media_manager_5/fields/getting_started.dcl
+++ b/MM/6.6.2/config/media_manager_5/fields/getting_started.dcl
@@ -1,0 +1,8 @@
+resource configservice_bit_config_field getting_started {
+    default_value = true
+    product_id = resource.configservice_product.media_manager_5.id
+    group = 'Intro screen'
+    key = 'gettingStarted'
+    title = 'Getting started'
+    description = 'If this is enabled, users with no folders will see Getting Started guidance for creating a folder and uploading assets.'
+}

--- a/MM/6.6.2/config/media_manager_5/labels/Asset List.dcl
+++ b/MM/6.6.2/config/media_manager_5/labels/Asset List.dcl
@@ -2874,7 +2874,7 @@ resource configservice_label asset_list_getting_started_folders_description {
       language_id = data.language.english.id
     },
     {
-      default_translation = 'Opret en mappe for at organisere dine aktiver, eller træk og slip en mappe fra din computer — dens struktur bliver gengivet automatisk.'
+      default_translation = 'Opret en mappe for at organisere dine assets, eller træk og slip en mappe fra din computer — dens struktur bliver gengivet automatisk.'
       language_id = data.language.danish.id
     }
   ]
@@ -2906,7 +2906,7 @@ resource configservice_label asset_list_getting_started_assets_title {
       language_id = data.language.english.id
     },
     {
-      default_translation = 'Ingen aktiver endnu'
+      default_translation = 'Ingen assets endnu'
       language_id = data.language.danish.id
     }
   ]
@@ -2922,7 +2922,7 @@ resource configservice_label asset_list_getting_started_assets_description {
       language_id = data.language.english.id
     },
     {
-      default_translation = 'Træk og slip filer her for at uploade, eller klik nedenfor for at gennemse. Slipper du en mappe, gengives dens struktur, og alle aktiver i den importeres.'
+      default_translation = 'Træk og slip filer her for at uploade, eller klik nedenfor for at gennemse. Slipper du en mappe, gengives dens struktur, og alle filer i den importeres.'
       language_id = data.language.danish.id
     }
   ]
@@ -2938,7 +2938,7 @@ resource configservice_label asset_list_getting_started_upload_assets {
       language_id = data.language.english.id
     },
     {
-      default_translation = 'Upload aktiver'
+      default_translation = 'Upload assets'
       language_id = data.language.danish.id
     }
   ]

--- a/MM/6.6.2/config/media_manager_5/labels/Asset List.dcl
+++ b/MM/6.6.2/config/media_manager_5/labels/Asset List.dcl
@@ -2848,3 +2848,114 @@ resource configservice_label asset_list_list_deleted_asset {
     }
   ]
 }
+resource configservice_label asset_list_getting_started_folders_title {
+  key = 'ASSET_LIST_GETTING_STARTED_FOLDERS_TITLE'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'No folders yet'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Ingen mapper endnu'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label asset_list_getting_started_folders_description {
+  key = 'ASSET_LIST_GETTING_STARTED_FOLDERS_DESCRIPTION'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Create a folder to organise your assets, or drag and drop a folder from your computer — its structure will be replicated automatically.'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Opret en mappe for at organisere dine aktiver, eller træk og slip en mappe fra din computer — dens struktur bliver gengivet automatisk.'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label asset_list_getting_started_create_folder {
+  key = 'ASSET_LIST_GETTING_STARTED_CREATE_FOLDER'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Create a folder'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Opret en mappe'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label asset_list_getting_started_assets_title {
+  key = 'ASSET_LIST_GETTING_STARTED_ASSETS_TITLE'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'No assets yet'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Ingen aktiver endnu'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label asset_list_getting_started_assets_description {
+  key = 'ASSET_LIST_GETTING_STARTED_ASSETS_DESCRIPTION'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Drag and drop files here to upload, or click below to browse. Dropping a folder will replicate its structure and import all assets inside.'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Træk og slip filer her for at uploade, eller klik nedenfor for at gennemse. Slipper du en mappe, gengives dens struktur, og alle aktiver i den importeres.'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label asset_list_getting_started_upload_assets {
+  key = 'ASSET_LIST_GETTING_STARTED_UPLOAD_ASSETS'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Upload assets'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Upload aktiver'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label asset_list_getting_started_dismiss_tooltip {
+  key = 'ASSET_LIST_GETTING_STARTED_DISMISS_TOOLTIP'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Dismiss'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Afvis'
+      language_id = data.language.danish.id
+    }
+  ]
+}

--- a/MM/6.7.0/config/media_manager_5/fields/getting_started.dcl
+++ b/MM/6.7.0/config/media_manager_5/fields/getting_started.dcl
@@ -1,0 +1,8 @@
+resource configservice_bit_config_field getting_started {
+    default_value = true
+    product_id = resource.configservice_product.media_manager_5.id
+    group = 'Intro screen'
+    key = 'gettingStarted'
+    title = 'Getting started'
+    description = 'If this is enabled, users with no folders will see Getting Started guidance for creating a folder and uploading assets.'
+}

--- a/MM/6.7.0/config/media_manager_5/labels/Asset List.dcl
+++ b/MM/6.7.0/config/media_manager_5/labels/Asset List.dcl
@@ -2874,7 +2874,7 @@ resource configservice_label asset_list_getting_started_folders_description {
       language_id = data.language.english.id
     },
     {
-      default_translation = 'Opret en mappe for at organisere dine aktiver, eller træk og slip en mappe fra din computer — dens struktur bliver gengivet automatisk.'
+      default_translation = 'Opret en mappe for at organisere dine assets, eller træk og slip en mappe fra din computer — dens struktur bliver gengivet automatisk.'
       language_id = data.language.danish.id
     }
   ]
@@ -2906,7 +2906,7 @@ resource configservice_label asset_list_getting_started_assets_title {
       language_id = data.language.english.id
     },
     {
-      default_translation = 'Ingen aktiver endnu'
+      default_translation = 'Ingen assets endnu'
       language_id = data.language.danish.id
     }
   ]
@@ -2922,7 +2922,7 @@ resource configservice_label asset_list_getting_started_assets_description {
       language_id = data.language.english.id
     },
     {
-      default_translation = 'Træk og slip filer her for at uploade, eller klik nedenfor for at gennemse. Slipper du en mappe, gengives dens struktur, og alle aktiver i den importeres.'
+      default_translation = 'Træk og slip filer her for at uploade, eller klik nedenfor for at gennemse. Slipper du en mappe, gengives dens struktur, og alle filer i den importeres.'
       language_id = data.language.danish.id
     }
   ]
@@ -2938,7 +2938,7 @@ resource configservice_label asset_list_getting_started_upload_assets {
       language_id = data.language.english.id
     },
     {
-      default_translation = 'Upload aktiver'
+      default_translation = 'Upload assets'
       language_id = data.language.danish.id
     }
   ]

--- a/MM/6.7.0/config/media_manager_5/labels/Asset List.dcl
+++ b/MM/6.7.0/config/media_manager_5/labels/Asset List.dcl
@@ -2848,3 +2848,114 @@ resource configservice_label asset_list_list_deleted_asset {
     }
   ]
 }
+resource configservice_label asset_list_getting_started_folders_title {
+  key = 'ASSET_LIST_GETTING_STARTED_FOLDERS_TITLE'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'No folders yet'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Ingen mapper endnu'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label asset_list_getting_started_folders_description {
+  key = 'ASSET_LIST_GETTING_STARTED_FOLDERS_DESCRIPTION'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Create a folder to organise your assets, or drag and drop a folder from your computer — its structure will be replicated automatically.'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Opret en mappe for at organisere dine aktiver, eller træk og slip en mappe fra din computer — dens struktur bliver gengivet automatisk.'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label asset_list_getting_started_create_folder {
+  key = 'ASSET_LIST_GETTING_STARTED_CREATE_FOLDER'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Create a folder'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Opret en mappe'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label asset_list_getting_started_assets_title {
+  key = 'ASSET_LIST_GETTING_STARTED_ASSETS_TITLE'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'No assets yet'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Ingen aktiver endnu'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label asset_list_getting_started_assets_description {
+  key = 'ASSET_LIST_GETTING_STARTED_ASSETS_DESCRIPTION'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Drag and drop files here to upload, or click below to browse. Dropping a folder will replicate its structure and import all assets inside.'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Træk og slip filer her for at uploade, eller klik nedenfor for at gennemse. Slipper du en mappe, gengives dens struktur, og alle aktiver i den importeres.'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label asset_list_getting_started_upload_assets {
+  key = 'ASSET_LIST_GETTING_STARTED_UPLOAD_ASSETS'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Upload assets'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Upload aktiver'
+      language_id = data.language.danish.id
+    }
+  ]
+}
+
+resource configservice_label asset_list_getting_started_dismiss_tooltip {
+  key = 'ASSET_LIST_GETTING_STARTED_DISMISS_TOOLTIP'
+  group = 'Asset List'
+  product_id = resource.configservice_product.media_manager_5.id
+  default_label_values = [
+    {
+      default_translation = 'Dismiss'
+      language_id = data.language.english.id
+    },
+    {
+      default_translation = 'Afvis'
+      language_id = data.language.danish.id
+    }
+  ]
+}


### PR DESCRIPTION
@
## MM5-8097 — Getting started functionality

Adds the backend config needed by the MM5 frontend Getting Started feature.

### Changes
Applied to **both** `MM/6.6.1` and `MM/6.7.0` (`config/media_manager_5`):

**New portal config field** (`fields/getting_started.dcl`)
- `configservice_bit_config_field`, key `gettingStarted`, default `true`, group `Intro screen`
- Frontend reads it to decide whether to show the "Create a folder" getting-started card to users with no folders. Dismiss (X) writes it back to `false` portal-wide.

**New labels** (`labels/Asset List.dcl`) — EN + DA:
- `ASSET_LIST_GETTING_STARTED_FOLDERS_TITLE`
- `ASSET_LIST_GETTING_STARTED_FOLDERS_DESCRIPTION`
- `ASSET_LIST_GETTING_STARTED_CREATE_FOLDER`
- `ASSET_LIST_GETTING_STARTED_ASSETS_TITLE`
- `ASSET_LIST_GETTING_STARTED_ASSETS_DESCRIPTION`
- `ASSET_LIST_GETTING_STARTED_UPLOAD_ASSETS`
- `ASSET_LIST_GETTING_STARTED_DISMISS_TOOLTIP`

### Related
- Jira: MM5-8097
- Frontend counterpart: mm5 branch `MM5-8097`

> Note: Danish translations are a first pass — please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@