### PR TITLE
MM5-8097 Getting Started disabled out-of-the-box (default_value false)

### DIFF
--- a/MM/6.6.1/config/media_manager_5/fields/getting_started.dcl
+++ b/MM/6.6.1/config/media_manager_5/fields/getting_started.dcl
@@ -1,5 +1,5 @@
 resource configservice_bit_config_field getting_started {
-    default_value = true
+    default_value = false
     product_id = resource.configservice_product.media_manager_5.id
     group = 'Intro screen'
     key = 'gettingStarted'

--- a/MM/6.6.2/config/media_manager_5/fields/getting_started.dcl
+++ b/MM/6.6.2/config/media_manager_5/fields/getting_started.dcl
@@ -1,5 +1,5 @@
 resource configservice_bit_config_field getting_started {
-    default_value = true
+    default_value = false
     product_id = resource.configservice_product.media_manager_5.id
     group = 'Intro screen'
     key = 'gettingStarted'

--- a/MM/6.7.0/config/media_manager_5/fields/getting_started.dcl
+++ b/MM/6.7.0/config/media_manager_5/fields/getting_started.dcl
@@ -1,5 +1,5 @@
 resource configservice_bit_config_field getting_started {
-    default_value = true
+    default_value = false
     product_id = resource.configservice_product.media_manager_5.id
     group = 'Intro screen'
     key = 'gettingStarted'


### PR DESCRIPTION
## What

Sets the `gettingStarted` portal-config field `default_value` from `true` to `false` in all shipped versions (6.6.1, 6.6.2, 6.7.0).

## Why

Follow-up to #1066. The Getting Started guidance must be **disabled out-of-the-box** (per Magnus's plan) — enabled only when a portal explicitly turns the flag on. With `default_value = true`, every workspace without an explicit override (new workspaces, users without portal-config access) inherited `true` and saw the Getting Started cards. The MM5 frontend `?? false` guard only covers a totally-absent value, so the real default lives here.

## Change

`MM/{6.6.1,6.6.2,6.7.0}/config/media_manager_5/fields/getting_started.dcl`: `default_value = true` → `default_value = false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)